### PR TITLE
Add timeline changes from AnimationWorklet spec updates

### DIFF
--- a/animation-worklet/anim-worklet.js
+++ b/animation-worklet/anim-worklet.js
@@ -99,21 +99,21 @@ limitations under the License.
       }
 
       attach(animation) {
-        var index = animation.additionalTimelines_.indexOf(this);
+        var mainThreadInstance = workletInstanceMap.get(animation);
+        var index = mainThreadInstance.additionalTimelines_.indexOf(this);
         if (index != -1)
           return;
-        var mainThreadInstance = workletInstanceMap.get(animation);
         this.attachInternal_(mainThreadInstance);
-        animation.additionalTimelines_.push(this);
+        mainThreadInstance.additionalTimelines_.push(this);
       }
 
       detach(animation) {
-        var index = animation.additionalTimelines_.lastIndexOf(this);
+        var mainThreadInstance = workletInstanceMap.get(animation);
+        var index = mainThreadInstance.additionalTimelines_.lastIndexOf(this);
         if (index == -1)
           return;
-        var mainThreadInstance = workletInstanceMap.get(animation);
         this.detachInternal_(mainThreadInstance);
-        animation.additionalTimelines_.splice(index, 1);
+        mainThreadInstance.additionalTimelines_.splice(index, 1);
       }
 
       attachInternal_(animation, isPrimary) {
@@ -267,6 +267,8 @@ limitations under the License.
         this.options = options;
         this.needsUpdate_ = false;
         this.instance_ = null;
+        // This stores additional timelines which have been attached.
+        this.additionalTimelines_ = []
         if (ctors[name]) {
           this.constructInstance_(ctors[name]);
         } else {
@@ -314,8 +316,6 @@ limitations under the License.
         // Save a map from instance back to this worklet animation without
         // exposing it to the user script.
         workletInstanceMap.set(this.instance_, this);
-        // This stores additional timelines which have been attached.
-        this.instance_.additionalTimelines_ = []
         if (this.playState == 'pending') {
           this.playState = 'running';
           this.setNeedsUpdate_();
@@ -340,8 +340,8 @@ limitations under the License.
             break;
           }
         }
-        for (var i = 0; i < this.instance_.additionalTimelines_.length; i++) {
-          if (this.instance_.additionalTimelines_[i] instanceof DocumentTimeline) {
+        for (var i = 0; i < this.additionalTimelines_.length; i++) {
+          if (this.additionalTimelines_[i] instanceof DocumentTimeline) {
             this.setNeedsUpdate_();
             break;
           }

--- a/animation-worklet/anim-worklet.js
+++ b/animation-worklet/anim-worklet.js
@@ -355,7 +355,7 @@ limitations under the License.
       }
 
       updateAnimation_() {
-        this.instance_.animate(this.timeline, this.effects);
+        this.instance_.animate(this.timeline.currentTime, this.effects);
         this.needsUpdate_ = false;
         // If this animation has any document timelines it will need an update
         // next frame.

--- a/animation-worklet/anim-worklet.js
+++ b/animation-worklet/anim-worklet.js
@@ -303,10 +303,15 @@ limitations under the License.
         for (var i = 0; i < this.timelines.length; i++) {
           this.timelines[i].detachInternal_(this);
         }
+        for (var i = this.additionalTimelines_.length - 1; i >= 0; --i) {
+          this.additionalTimelines_[i].detachInternal_(this);
+        }
+        this.additionalTimelines_ = [];
         for (var i = 0; i < this.effects.length; i++) {
-          this.effects[i]._target.style.willChange = '';
+          this.effects[i].effect_._target.style.willChange = '';
         }
         this.playState = 'idle';
+        delete this.instance_;
         if (this.needsUpdate_);
           cancelUpdateAnimation(this);
       }

--- a/animation-worklet/expando/expand-animator.js
+++ b/animation-worklet/expando/expand-animator.js
@@ -18,10 +18,10 @@ registerAnimator('expand', class ExpandAnimator {
     this.options = options;
   }
 
-  animate(timeline, effects) {
+  animate(currentTime, effects) {
     // TODO(flackr): Control transition through input.
     // TODO(flackr): Use non-linear transition.
-    var repeatTime = timeline.currentTime * 0.001 % 5;
+    var repeatTime = currentTime * 0.001 % 5;
     var t = 0;
     if (repeatTime < 2)
       t = Math.max(0, repeatTime - 1);

--- a/animation-worklet/expando/expand-animator.js
+++ b/animation-worklet/expando/expand-animator.js
@@ -18,10 +18,10 @@ registerAnimator('expand', class ExpandAnimator {
     this.options = options;
   }
 
-  animate(timelines, effects) {
+  animate(timeline, effects) {
     // TODO(flackr): Control transition through input.
     // TODO(flackr): Use non-linear transition.
-    var repeatTime = timelines[0].currentTime * 0.001 % 5;
+    var repeatTime = timeline.currentTime * 0.001 % 5;
     var t = 0;
     if (repeatTime < 2)
       t = Math.max(0, repeatTime - 1);

--- a/animation-worklet/expando/index.html
+++ b/animation-worklet/expando/index.html
@@ -89,7 +89,7 @@ limitations under the License.
         new KeyframeEffect(offset, [{'transform': 'translateY(0)'}, {'transform': 'translateY(' + (0.5 * expando.clientWidth * (expandScale - 1)) + 'px)'}], effectOptions),
         new KeyframeEffect(smallContent, [{'opacity': 1}, {'opacity': 0}], effectOptions),
         new KeyframeEffect(largeContent, [{'opacity': 0}, {'opacity': 1}], effectOptions),
-      ], [new DocumentTimeline()], {'expandScale': expandScale});
+      ], new DocumentTimeline(), {'expandScale': expandScale});
     window.expandoAnimator.play();
   });
 </script>

--- a/animation-worklet/parallax-scrolling/parallax-animator.js
+++ b/animation-worklet/parallax-scrolling/parallax-animator.js
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 registerAnimator('parallax', class ParallaxAnimator {
-  animate(timeline, effects) {
-    effects[0].localTime = 200 * timeline.currentTime;
+  animate(currentTime, effects) {
+    effects[0].localTime = 200 * currentTime;
   }
 });

--- a/animation-worklet/parallax-scrolling/parallax-animator.js
+++ b/animation-worklet/parallax-scrolling/parallax-animator.js
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 registerAnimator('parallax', class ParallaxAnimator {
-  animate(timelines, effects) {
-    effects[0].localTime = 200 * timelines[0].currentTime;
+  animate(timeline, effects) {
+    effects[0].localTime = 200 * timeline.currentTime;
   }
 });

--- a/animation-worklet/parallax-scrolling/parallax.js
+++ b/animation-worklet/parallax-scrolling/parallax.js
@@ -61,7 +61,7 @@ document.addEventListener('DOMContentLoaded', function() {
     var scrollRange = scroller.scrollHeight - scroller.clientHeight;
     window.parallaxAnimator = new WorkletAnimation('parallax',
         [new KeyframeEffect(parallax, [{'transform': 'translateY(0)'}, {'transform': 'translateY(' + -scrollRange + 'px)'}], scrollRange)],
-        [new ScrollTimeline({scrollSource: scroller, orientation: 'vertical'})]);
+        new ScrollTimeline({scrollSource: scroller, orientation: 'vertical'}));
     window.parallaxAnimator.play();
   }
 });

--- a/animation-worklet/spring-sticky/index.html
+++ b/animation-worklet/spring-sticky/index.html
@@ -119,8 +119,8 @@ document.addEventListener('DOMContentLoaded', function() {
   for (var i = 0; i < boxes.length; i++) {
     effects.push(new KeyframeEffect(boxes[i], [{'transform': 'translateY(0)'}, {'transform': 'translateY(' + scrollRange + 'px)'}], scrollRange));
   }
-  window.stickyAnimation = new WorkletAnimation('spring-sticky', effects, [
-    new ScrollTimeline({scrollSource: scroller, timeRange: scrollRange})],
+  window.stickyAnimation = new WorkletAnimation('spring-sticky', effects,
+    new ScrollTimeline({scrollSource: scroller, timeRange: scrollRange}),
     {'documentTimeline': new DocumentTimeline()});
   window.stickyAnimation.play();
 });

--- a/animation-worklet/spring-sticky/index.html
+++ b/animation-worklet/spring-sticky/index.html
@@ -120,8 +120,8 @@ document.addEventListener('DOMContentLoaded', function() {
     effects.push(new KeyframeEffect(boxes[i], [{'transform': 'translateY(0)'}, {'transform': 'translateY(' + scrollRange + 'px)'}], scrollRange));
   }
   window.stickyAnimation = new WorkletAnimation('spring-sticky', effects, [
-    new DocumentTimeline(),
-    new ScrollTimeline({scrollSource: scroller, timeRange: scrollRange})]);
+    new ScrollTimeline({scrollSource: scroller, timeRange: scrollRange})],
+    {'documentTimeline': new DocumentTimeline()});
   window.stickyAnimation.play();
 });
 </script>

--- a/animation-worklet/spring-sticky/spring-sticky-animator.js
+++ b/animation-worklet/spring-sticky/spring-sticky-animator.js
@@ -17,9 +17,12 @@ registerAnimator('spring-sticky', class SpringAnimator {
   constructor(options) {
     this.velocities = [];
     this.positions = [];
+    this.documentTimeline = options.documentTimeline;
   }
 
   animate(timelines, effects) {
+    // Attach to the document timeline whenever a scroll happens.
+    this.documentTimeline.attach(this);
     var boxes = effects;
     if (boxes.length != this.velocities.length) {
       // If number of elements change, stored state is no longer correct.
@@ -30,21 +33,28 @@ registerAnimator('spring-sticky', class SpringAnimator {
         this.positions.push(0);
       }
     }
-    var targetPos = timelines[1].currentTime;
+    var targetPos = timelines[0].currentTime;
+    var changed = false;
     for (var i = 0; i < boxes.length; i++) {
       if (i == 0) {
         // Box 0 stays stuck.
-        this.positions[i] = targetPos;
+        boxes[i].localTime = this.positions[i] = targetPos;
       } else {
         var delta = Math.max(-20, Math.min(20, targetPos - this.positions[i]));
         this.velocities[i] = this.velocities[i] * 0.95 + delta * 0.05;
-        this.positions[i] += this.velocities[i];
         // Positions cannot stretch, but can collapse.
-        this.positions[i] = Math.max(targetPos - 100, Math.min(targetPos, this.positions[i]));
+        var newPosition = Math.max(targetPos - 100, Math.min(targetPos, this.positions[i] + this.velocities[i]));
+        if (newPosition != this.positions[i]) {
+          boxes[i].localTime = this.positions[i] = newPosition;
+          changed = true;
+        }
       }
-      boxes[i].localTime = this.positions[i];
       targetPos = this.positions[i];
     }
+    // If the animation has reached a stable state we no longer need to stay
+    // attached to the document timeline.
+    if (!changed)
+      this.documentTimeline.detach(this);
   }
 
 });

--- a/animation-worklet/spring-sticky/spring-sticky-animator.js
+++ b/animation-worklet/spring-sticky/spring-sticky-animator.js
@@ -20,7 +20,7 @@ registerAnimator('spring-sticky', class SpringAnimator {
     this.documentTimeline = options.documentTimeline;
   }
 
-  animate(timelines, effects) {
+  animate(timeline, effects) {
     // Attach to the document timeline whenever a scroll happens.
     this.documentTimeline.attach(this);
     var boxes = effects;
@@ -33,7 +33,7 @@ registerAnimator('spring-sticky', class SpringAnimator {
         this.positions.push(0);
       }
     }
-    var targetPos = timelines[0].currentTime;
+    var targetPos = timeline.currentTime;
     var changed = false;
     for (var i = 0; i < boxes.length; i++) {
       if (i == 0) {

--- a/animation-worklet/spring-sticky/spring-sticky-animator.js
+++ b/animation-worklet/spring-sticky/spring-sticky-animator.js
@@ -20,7 +20,7 @@ registerAnimator('spring-sticky', class SpringAnimator {
     this.documentTimeline = options.documentTimeline;
   }
 
-  animate(timeline, effects) {
+  animate(currentTime, effects) {
     // Attach to the document timeline whenever a scroll happens.
     this.documentTimeline.attach(this);
     var boxes = effects;
@@ -33,7 +33,7 @@ registerAnimator('spring-sticky', class SpringAnimator {
         this.positions.push(0);
       }
     }
-    var targetPos = timeline.currentTime;
+    var targetPos = currentTime;
     var changed = false;
     for (var i = 0; i < boxes.length; i++) {
       if (i == 0) {

--- a/animation-worklet/spring-timing/index.html
+++ b/animation-worklet/spring-timing/index.html
@@ -51,7 +51,7 @@ limitations under the License.
       var range = options[options.length - 1].target * 2;
       effects.push(new KeyframeEffect(elems[i], [{'transform': 'translateX(0)'}, {'transform': 'translateX(' + range + 'px)'}], range));
     }
-    window.springAnimation = new WorkletAnimation('spring', effects, [new DocumentTimeline()], options);
+    window.springAnimation = new WorkletAnimation('spring', effects, new DocumentTimeline(), options);
     window.springAnimation.play();
   });
 </script>

--- a/animation-worklet/spring-timing/spring-timing-animator.js
+++ b/animation-worklet/spring-timing/spring-timing-animator.js
@@ -18,8 +18,7 @@ registerAnimator('spring', class SpringAnimator {
     this.options = options;
   }
 
-  animate(timelines, effects) {
-    var timeline = timelines[0];
+  animate(timeline, effects) {
     for (var i = 0; i < effects.length; i++) {
       var e = effects[i];
       var params =this.options[i];

--- a/animation-worklet/spring-timing/spring-timing-animator.js
+++ b/animation-worklet/spring-timing/spring-timing-animator.js
@@ -18,7 +18,7 @@ registerAnimator('spring', class SpringAnimator {
     this.options = options;
   }
 
-  animate(timeline, effects) {
+  animate(currentTime, effects) {
     for (var i = 0; i < effects.length; i++) {
       var e = effects[i];
       var params =this.options[i];
@@ -27,12 +27,12 @@ registerAnimator('spring', class SpringAnimator {
         const k = params.k;
         const ratio = Math.min(params.ratio, 1 - 1e-5);
 
-        e.startTime_ = timeline.currentTime;
+        e.startTime_ = currentTime;
         e.springTiming_ = this.spring(k, ratio);
       }
       const target = params.target;
       // TODO(majidvp): stop computing a new value once we are withing a certainer threshold of the target.
-      const dt_seconds = (timeline.currentTime - e.startTime_) / 1000;
+      const dt_seconds = (currentTime - e.startTime_) / 1000;
       const dv = target * e.springTiming_(dt_seconds);
 
       e.localTime = dv;

--- a/animation-worklet/twitter-header/index.html
+++ b/animation-worklet/twitter-header/index.html
@@ -67,12 +67,10 @@ limitations under the License.
               new KeyframeEffect(avatar, [{'transform': 'translateY(0)'}, {'transform': 'translateY(' + scrollRange + 'px)'}], scrollRange),
               new KeyframeEffect(bar, [{'transform': 'translateY(0)'}, {'transform': 'translateY(' + scrollRange + 'px)'}], scrollRange),
               new KeyframeEffect(barSection, [{'opacity': 0}, {'opacity': 1}], {duration: 144, fill: 'both'}),
-            ], [
-              new ScrollTimeline({scrollSource: scroller, orientation: 'vertical'}),
-              new ScrollTimeline({scrollSource: scroller, orientation: 'vertical',
-                  endScrollOffset: '144px', timeRange: 144})
-            ], {
-              scrollRange: scrollRange
+            ], new ScrollTimeline({scrollSource: scroller, orientation: 'vertical'}), {
+              avatarTimeline: new ScrollTimeline({scrollSource: scroller, orientation: 'vertical',
+                  endScrollOffset: '144px', timeRange: 144}),
+              scrollRange: scrollRange,
             });
           window.twitterAnimation.play();
         });

--- a/animation-worklet/twitter-header/twitter-header-animator.js
+++ b/animation-worklet/twitter-header/twitter-header-animator.js
@@ -16,18 +16,19 @@ limitations under the License.
 registerAnimator('twitter-header', class TwitterHeader {
   constructor(options) {
     this.options = options;
+    this.options.avatarTimeline.attach(this);
   }
 
-  animate(timelines, effects) {
-    var scrollPos = timelines[0].currentTime * this.options.scrollRange;
+  animate(timeline, effects) {
+    var scrollPos = timeline.currentTime * this.options.scrollRange;
     // Avatar scale
-    effects[0].localTime = timelines[1].currentTime;
+    effects[0].localTime = this.options.avatarTimeline.currentTime;
     // Avatar position
     effects[1].localTime = scrollPos > 189 - 45 * 0.6 ?
         scrollPos - (189 - 45 * 0.6) + 45 : 45;
     // Header bar position
     effects[2].localTime = scrollPos;
     // Header bar opacity
-    effects[3].localTime = timelines[1].currentTime;
+    effects[3].localTime = this.options.avatarTimeline.currentTime;
   }
 });

--- a/animation-worklet/twitter-header/twitter-header-animator.js
+++ b/animation-worklet/twitter-header/twitter-header-animator.js
@@ -19,8 +19,8 @@ registerAnimator('twitter-header', class TwitterHeader {
     this.options.avatarTimeline.attach(this);
   }
 
-  animate(timeline, effects) {
-    var scrollPos = timeline.currentTime * this.options.scrollRange;
+  animate(currentTime, effects) {
+    var scrollPos = currentTime * this.options.scrollRange;
     // Avatar scale
     effects[0].localTime = this.options.avatarTimeline.currentTime;
     // Avatar position


### PR DESCRIPTION
This updates the polyfill to use the latest changes in the AnimationWorklet spec including:
- Using a single primary timeline (polyfill supports attaching / detaching to additional timelines passed in options).
- Passing the currentTime rather than the timeline into the animation.