### PR TITLE
Tackling moving paintWorklet under the CSS global JS API Module

### DIFF
--- a/paint-worklet/border-color/index.html
+++ b/paint-worklet/border-color/index.html
@@ -71,5 +71,5 @@ limitations under the License.
     initialValue: '0',
   });
 });
-paintWorklet.addModule('border-colors.js');
+CSS.paintWorklet.addModule('border-colors.js');
 </script>

--- a/paint-worklet/circle/index.html
+++ b/paint-worklet/circle/index.html
@@ -27,5 +27,5 @@ limitations under the License.
 </style>
 
 <script>
-window.paintWorklet.addModule('paintworklet.js');
+CSS.paintWorklet.addModule('paintworklet.js');
 </script>

--- a/paint-worklet/ripple/index.html
+++ b/paint-worklet/ripple/index.html
@@ -44,7 +44,7 @@ limitations under the License.
 </style>
 
 <script>
-window.paintWorklet.addModule('paintworklet.js');
+CSS.paintWorklet.addModule('paintworklet.js');
 const button = document.querySelector('#ripple');
 let start = performance.now();
 let x, y;


### PR DESCRIPTION
Changing window.paintWorklet -> CSS.paintWorklet
to make demos work in Chrome Canary (62)
Chrome stable still requires window.paintWorklet for now, but demos don't work in them anyway (the stable version has a broken version of the paint worklet, which doesn't actually provide the result of the paint).